### PR TITLE
Compile with latest jedis dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This works around the issue described here: https://github.com/xetorthio/jedis/issues/303
